### PR TITLE
Add className prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When the xml is invalid, invalidXml component will be returned.\
 **Default**: `<div>Invalid XML!</div>`
 
 ### className (string)
-An optional class name to be applied to the root element
+An optional class name to be applied to the root element.\
 **Default**: `''`
 
 ### collapsible (boolean)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The size of the indentation.\
 When the xml is invalid, invalidXml component will be returned.\
 **Default**: `<div>Invalid XML!</div>`
 
+### className (string)
+An optional class name to be applied to the root element
+**Default**: `''`
+
 ### collapsible (boolean)
 Allow collapse/expand tags by click on them. When tag is collapsed its content and attributes are hidden.\
 **Default**: false

--- a/src/components/XMLViewer.tsx
+++ b/src/components/XMLViewer.tsx
@@ -11,6 +11,7 @@ export default function XMLViewer(props: XMLViewerProps): JSX.Element {
   const {
     theme: customTheme,
     xml,
+    className = '',
     collapsible = false,
     indentSize = 2,
     invalidXml,
@@ -37,7 +38,7 @@ export default function XMLViewer(props: XMLViewerProps): JSX.Element {
   return (
     <XMLViewerContext.Provider value={context}>
       <div
-        className="rxv-container"
+        className={`rxv-container ${className}`}
         style={{ whiteSpace: 'pre-wrap', fontFamily: theme.fontFamily, overflowWrap: 'break-word' }}
       >
         <Elements elements={json} />

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -52,6 +52,10 @@ export interface XMLViewerProps {
    */
   invalidXml?: JSX.Element;
   /**
+   * @default ''
+   */
+  className?: string;
+  /**
    * @default false
    */
   collapsible?: boolean;


### PR DESCRIPTION
Resolve https://github.com/alissonmbr/react-xml-viewer/issues/67

Accept a `className` prop that is applied to the root element.

```
<XMLViewer xml={xml} className="my-custom-class-name" />
```

I started the pull request, but feel free to add more changes to it to make it ready.